### PR TITLE
Remove unneccessary python requirement discriptors

### DIFF
--- a/recipes/moose-compilers/recipe/conda_build_config.yaml
+++ b/recipes/moose-compilers/recipe/conda_build_config.yaml
@@ -9,10 +9,3 @@ macos_machine:                 # [osx]
 
 MACOSX_DEPLOYMENT_TARGET:      # [osx]
   - 10.9                       # [osx]
-
-python:
-  - 3.7
-  - 3.6
-
-pin_run_as_build:
-  python: x.x

--- a/recipes/moose-compilers/recipe/meta.yaml
+++ b/recipes/moose-compilers/recipe/meta.yaml
@@ -20,7 +20,6 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - {{ compiler('fortran') }}
-    - python {{ python }}
     - libpng
     - clang-tools  # [osx]
 

--- a/recipes/moose-python-deps/recipe/conda_build_config.yaml
+++ b/recipes/moose-python-deps/recipe/conda_build_config.yaml
@@ -1,9 +1,2 @@
 moose_pylatexenc:
   - 2.1
-
-python:
-  - 3.7
-  - 3.6
-
-pin_run_as_build:
-  python: x.x

--- a/recipes/moose-python-deps/recipe/meta.yaml
+++ b/recipes/moose-python-deps/recipe/meta.yaml
@@ -16,7 +16,6 @@ build:
 
 requirements:
   run:
-    - python {{ python }}
     - pyqt
     - matplotlib
     - pandas


### PR DESCRIPTION
My thinking, is that we only place python requirements in things
actually requiring python. The dependency does not need to exist
anywhere else up the dependency chain.

While this makes total sense, I am still not sure why the current
configuration fails due to conflicts.

Refs #21