### PR TITLE
Understanding the dependency chain a bit more...

### DIFF
--- a/recipes/moose-compilers/recipe/meta.yaml
+++ b/recipes/moose-compilers/recipe/meta.yaml
@@ -16,14 +16,12 @@ build:
 
 requirements:
   run:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - {{ compiler('fortran') }}
     - moose-mpich
     - libpng
-    - clang
-    - clang-tools
-    - clangdev
-    - clangxx
-    - libclang
-    - python-clang
+    - clang-tools  # [osx]
 
 test:
   commands:

--- a/recipes/moose-dev/recipe/conda_build_config.yaml
+++ b/recipes/moose-dev/recipe/conda_build_config.yaml
@@ -1,0 +1,5 @@
+moose_libmesh:
+ - 2019.12.19
+
+pin_run_as_build:
+  moose_libmesh: x.x.x

--- a/recipes/moose-dev/recipe/meta.yaml
+++ b/recipes/moose-dev/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "moose-dev" %}
-{% set version = "2019.12.19" %}
+{% set version = "2020.01.23" %}
 {% set sha256 = "60ccefaa5220e8b7608bc8fccdbf5a84fd9c50e6ca6c39ba5a121454a47313f8" %}
 
 package:
@@ -15,6 +15,8 @@ build:
   skip: true # [win]
 
 requirements:
+  build:
+    - moose-libmesh {{ moose_libmesh }}
   run:
     - moose-libmesh
 

--- a/recipes/moose-env/recipe/conda_build_config.yaml
+++ b/recipes/moose-env/recipe/conda_build_config.yaml
@@ -1,0 +1,5 @@
+moose_dev:
+ - 2020.01.23
+
+pin_run_as_build:
+  moose_dev: x.x.x

--- a/recipes/moose-env/recipe/meta.yaml
+++ b/recipes/moose-env/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "moose-env" %}
-{% set version = "2020.01.21" %}
+{% set version = "2020.01.23" %}
 {% set sha256 = "1f9e83570f0670511998f609a2b4b3ddd5dc02563b052b6cd3af24a59452cece" %}
 
 package:
@@ -15,6 +15,8 @@ build:
   skip: true # [win]
 
 requirements:
+  build:
+    - moose-dev {{ moose_dev }}
   run:
     - moose-dev
     - moose-python-deps

--- a/recipes/moose-libmesh/recipe/conda_build_config.yaml
+++ b/recipes/moose-libmesh/recipe/conda_build_config.yaml
@@ -20,3 +20,10 @@ moose_libmesh_vtk:
 SHORT_VTK_NAME:
   - 8.2 # [osx]
   - 6.3 # [linux]
+
+moose_petsc:
+ - 3.11.4
+
+pin_run_as_build:
+  moose_petsc: x.x.x
+  moose_libmesh_vtk: x.x.x

--- a/recipes/moose-libmesh/recipe/meta.yaml
+++ b/recipes/moose-libmesh/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "moose-libmesh" %}
 {% set version = "81589c1acb86765a0a1981b7fef5328e91fb92ab" %}
-{% set friendly_version = "2020.01.21" %}
+{% set friendly_version = "2019.12.19" %}
 {% set sha256 = "8f37b5d52ad764f8da5594a7b608fd8df6836038c0c187046861307cca0345bf" %}
 {% set metaphysicl_version = "78f338a1508b4010a39a34d9fec9ee6247afaecf" %}
 {% set metaphysicl_sha256 = "30ead616f1aad634ce270db2688f8c2b799a1f3b6a2f726a3bbf5abe1f923ac7" %}
@@ -29,8 +29,8 @@ requirements:
     - {{ compiler('cxx') }}
     - {{ compiler('fortran') }}
     - pkg-config
-    - moose-petsc
-    - moose-libmesh-vtk
+    - moose-petsc {{ moose_petsc }}
+    - moose-libmesh-vtk {{ moose_libmesh_vtk }}
     - cctools                                           # [osx]
     - ld64                                              # [osx]
 


### PR DESCRIPTION
Now that I _think_ I have a better understanding of the dependency chain,
lets try to create more. Ideally, we want to control what version(s) of
libMesh folks receive, based on what is available to moose-env/moose-dev
combinations.

Without that dependency chain, there is no dependency information between
moose-env --> moose-dev --> moose-libmesh (any update to libmesh, would
propagate to all users, regardless of what moose-env has configured, becuase
moose-env has no configuration).

Trigger a libMesh build, by downgrading the version. Once/if this passes, we
will trigger another build by _adding_ a version to moose-dev's conda_build_config,
and bumping the moose-libmesh version. See what happens.

Also, while we know the compilers are slow, add them back in for now. Speed-up
is going to have to wait until we know conda-dependencies is going to work
for us.

Refs #27