### PR TITLE
Fix missing moose-compilers

### DIFF
--- a/recipes/moose-mpich/recipe/meta.yaml
+++ b/recipes/moose-mpich/recipe/meta.yaml
@@ -14,6 +14,10 @@ build:
   number: {{ build }}
   skip: True  # [win]
 
+requirements:
+  run:
+    - moose-compilers {{ moose_compilers }}
+
 outputs:
   - name: moose-mpich
     script: build-mpi.sh


### PR DESCRIPTION
Lots to learn. Looks like 'outputs' is something special. Add requirements
field to include run dependencies. This will allow moose-mpich to require
moose-compilers when installed.

Refs #27