### PR TITLE
Trigger a new build of everything

### DIFF
--- a/recipes/autojump/recipe/build.sh
+++ b/recipes/autojump/recipe/build.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 set -eu
-
 ./install.py -f -d ${PREFIX} -p ${PREFIX}
-
 mkdir -p "${PREFIX}/etc/conda/activate.d" "${PREFIX}/etc/conda/deactivate.d"
 cat <<EOF > "${PREFIX}/etc/conda/activate.d/activate_${PKG_NAME}.sh"
 export AUTOJUMP_SHELL=\`ps -o comm= \$\$ | sed -e 's/-//'\`

--- a/recipes/autojump/recipe/meta.yaml
+++ b/recipes/autojump/recipe/meta.yaml
@@ -11,8 +11,8 @@ source:
     sha256: {{ sha256 }}
 
 build:
-  number: 1  # [linux,osx]
-  skip: true # [win]
+  number: 1  # [osx]
+  skip: true # [win,linux]
 
 requirements:
   build:

--- a/recipes/moose-compilers/recipe/meta.yaml
+++ b/recipes/moose-compilers/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "moose-compilers" %}
-{% set version = "2020.01.24" %}
+{% set version = "2020.01.27" %}
 {% set sha256 = "f8236c163aebbf8894381b7f71c42f3f3beeff6d8aee69b8a829cd76f7d5bd7a" %}
 
 package:

--- a/recipes/moose-dev/recipe/conda_build_config.yaml
+++ b/recipes/moose-dev/recipe/conda_build_config.yaml
@@ -2,7 +2,7 @@ moose_petsc:
  - 3.11.4
 
 moose_tools:
- - 2020.01.24
+ - 2020.01.27
 
 pin_run_as_build:
   moose_petsc: x.x.x

--- a/recipes/moose-dev/recipe/meta.yaml
+++ b/recipes/moose-dev/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "moose-dev" %}
-{% set version = "2020.01.24" %}
+{% set version = "2020.01.27" %}
 {% set sha256 = "60ccefaa5220e8b7608bc8fccdbf5a84fd9c50e6ca6c39ba5a121454a47313f8" %}
 
 package:

--- a/recipes/moose-env/recipe/conda_build_config.yaml
+++ b/recipes/moose-env/recipe/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_libmesh:
- - 2020.01.24
+ - 2020.01.27
 
 pin_run_as_build:
   moose_libmesh: x.x.x

--- a/recipes/moose-libmesh-vtk/recipe/build.sh
+++ b/recipes/moose-libmesh-vtk/recipe/build.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 set -eu
-
 if [[ $mpi == "openmpi" ]]; then
   export OMPI_MCA_plm=isolated
   export OMPI_MCA_rmaps_base_oversubscribe=yes

--- a/recipes/moose-libmesh-vtk/recipe/conda_build_config.yaml
+++ b/recipes/moose-libmesh-vtk/recipe/conda_build_config.yaml
@@ -23,7 +23,7 @@ MACOSX_DEPLOYMENT_TARGET:      # [osx]
   - 10.9                       # [osx]
 
 mpi:
-  - moose_mpich
+  - moose-mpich
 
 moose_mpich:
   - 3.3.2

--- a/recipes/moose-libmesh/recipe/conda_build_config.yaml
+++ b/recipes/moose-libmesh/recipe/conda_build_config.yaml
@@ -11,7 +11,7 @@ MACOSX_DEPLOYMENT_TARGET:      # [osx]
   - 10.9                       # [osx]
 
 mpi:
-  - moose_mpich
+  - moose-mpich
 
 SHORT_VTK_NAME:
   - 8.2 # [osx]

--- a/recipes/moose-libmesh/recipe/conda_build_config.yaml
+++ b/recipes/moose-libmesh/recipe/conda_build_config.yaml
@@ -18,7 +18,7 @@ SHORT_VTK_NAME:
   - 6.3 # [linux]
 
 moose_dev:
- - 2020.01.24
+ - 2020.01.27
 
 moose_libmesh_vtk:
   - 8.2.0 # [osx]

--- a/recipes/moose-libmesh/recipe/meta.yaml
+++ b/recipes/moose-libmesh/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "moose-libmesh" %}
 {% set version = "81589c1acb86765a0a1981b7fef5328e91fb92ab" %}
-{% set friendly_version = "2020.01.24" %}
+{% set friendly_version = "2020.01.27" %}
 {% set sha256 = "8f37b5d52ad764f8da5594a7b608fd8df6836038c0c187046861307cca0345bf" %}
 {% set metaphysicl_version = "78f338a1508b4010a39a34d9fec9ee6247afaecf" %}
 {% set metaphysicl_sha256 = "30ead616f1aad634ce270db2688f8c2b799a1f3b6a2f726a3bbf5abe1f923ac7" %}

--- a/recipes/moose-mpich/recipe/conda_build_config.yaml
+++ b/recipes/moose-mpich/recipe/conda_build_config.yaml
@@ -11,7 +11,7 @@ MACOSX_DEPLOYMENT_TARGET:      # [osx]
   - 10.9                       # [osx]
 
 moose_compilers:
-  - 2020.01.24
+  - 2020.01.27
 
 pin_run_as_build:
   moose_compilers: x.x.x

--- a/recipes/moose-petsc/recipe/meta.yaml
+++ b/recipes/moose-petsc/recipe/meta.yaml
@@ -22,31 +22,22 @@ build:
 requirements:
   build:
     - moose-mpich {{ moose_mpich }}
-    - python
     - pkg-config
 
   host:
     - libblas
     - libcblas
     - liblapack
-    - scalapack
-    - moose-mpich
-    - mumps-mpi
     - cmake
-    - {{ mpi }}
+    - moose-mpich
 
   run:
-    - {{ mpi }}
-    - moose-mpich
-    - mumps-mpi
-    - scalapack
+    - moose-mpich {{ moose_mpich }}
 
 test:
   requires:
     - pkg-config
-    - {{ compiler('c') }}
-    - {{ compiler('cxx') }}
-    - {{ compiler('fortran') }}
+    - moose-mpich {{ moose_mpich }}
 
   files:
     - tests/ex1.c

--- a/recipes/moose-tools/recipe/meta.yaml
+++ b/recipes/moose-tools/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "moose-tools" %}
-{% set version = "2020.01.24" %}
+{% set version = "2020.01.27" %}
 {% set sha256 = "3a12dc808c116f6593f7c95519ed2410b3e61bde9c3b426a58c07c7f6a6dd4c2" %}
 
 package:


### PR DESCRIPTION
Recover old formula for building PETSc. As that recipe is working. Alter
dependencies where necessary.

Trigger a build of autojump, so it becomes available.

Refs #27