### PR TITLE
Build a new set-environment

### DIFF
--- a/build_packages.sh
+++ b/build_packages.sh
@@ -83,7 +83,7 @@ print_and_run conda build purge-all
 exitIfReturnCode $?
 
 for formula in ${FORMULAS}; do
-    printf "Building $(basename $formula)...\nconda build -c https://mooseframework.org/conda/moose $formula\n"
+    printf "$(date): Building $(basename $formula)...\nconda build -c https://mooseframework.org/conda/moose $formula\n"
     conda build -c https://mooseframework.org/conda/moose $formula > possible_errors 2>&1
     if [ $? -ne 0 ]; then
         cat possible_errors

--- a/recipes/moose-compilers/recipe/meta.yaml
+++ b/recipes/moose-compilers/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set build = 0 %}
-{% set version = "2020.03.17." + build %}
+{% set version = "2020.03.17." + build|string %}
 
 {% set sha256 = "f8236c163aebbf8894381b7f71c42f3f3beeff6d8aee69b8a829cd76f7d5bd7a" %}
 

--- a/recipes/moose-compilers/recipe/meta.yaml
+++ b/recipes/moose-compilers/recipe/meta.yaml
@@ -1,10 +1,10 @@
-{% set name = "moose-compilers" %}
-{% set version = "2020.03.17.01" %}
 {% set build = 0 %}
+{% set version = "2020.03.17." + build %}
+
 {% set sha256 = "f8236c163aebbf8894381b7f71c42f3f3beeff6d8aee69b8a829cd76f7d5bd7a" %}
 
 package:
-  name: {{ name }}
+  name: moose-compilers
   version: {{ version }}
 
 source:
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0  # [linux,osx]
+  number: {{ build }}  # [linux,osx]
   skip: true # [win]
 
 requirements:

--- a/recipes/moose-compilers/recipe/meta.yaml
+++ b/recipes/moose-compilers/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "moose-compilers" %}
-{% set version = "2020.03.02" %}
+{% set version = "2020.03.17.01" %}
 {% set build = 0 %}
 {% set sha256 = "f8236c163aebbf8894381b7f71c42f3f3beeff6d8aee69b8a829cd76f7d5bd7a" %}
 

--- a/recipes/moose-libmesh-vtk/recipe/conda_build_config.yaml
+++ b/recipes/moose-libmesh-vtk/recipe/conda_build_config.yaml
@@ -11,7 +11,7 @@ MACOSX_DEPLOYMENT_TARGET:      # [osx]
   - 10.9                       # [osx]
 
 vtk_version:
-  - 6.3.0.01
+  - 6.3.0
 
 friendly_version:
   - 6.3
@@ -29,7 +29,7 @@ mpi:
   - moose-mpich
 
 moose_mpich:
-  - 3.3.2
+  - 3.3.2.0
 
 pin_run_as_build:
-  moose_mpich: x.x.x
+  moose_mpich: x.x.x.x

--- a/recipes/moose-libmesh-vtk/recipe/conda_build_config.yaml
+++ b/recipes/moose-libmesh-vtk/recipe/conda_build_config.yaml
@@ -11,7 +11,7 @@ MACOSX_DEPLOYMENT_TARGET:      # [osx]
   - 10.9                       # [osx]
 
 vtk_version:
-  - 6.3.0
+  - 6.3.0.01
 
 friendly_version:
   - 6.3

--- a/recipes/moose-libmesh-vtk/recipe/meta.yaml
+++ b/recipes/moose-libmesh-vtk/recipe/meta.yaml
@@ -2,7 +2,7 @@
 
 {% set vtk_version = vtk_version %}
 {% set friendly_version =  friendly_version %}
-{% set version =  vtk_version + "." + build %}
+{% set version =  vtk_version + "." + build|string %}
 {% set sha256 = sha256 %}
 
 package:

--- a/recipes/moose-libmesh-vtk/recipe/meta.yaml
+++ b/recipes/moose-libmesh-vtk/recipe/meta.yaml
@@ -1,18 +1,20 @@
+{% set build = 0 %}
+
 {% set vtk_version = vtk_version %}
 {% set friendly_version =  friendly_version %}
-{% set vtk_build = 0 %}
+{% set version =  vtk_version + "." + build %}
 {% set sha256 = sha256 %}
 
 package:
   name: moose-libmesh-vtk
-  version: {{ vtk_version }}
+  version: {{ version }}
 
 source:
   url: https://www.vtk.org/files/release/{{ friendly_version }}/VTK-{{ vtk_version }}.tar.gz
   sha256: {{ sha256 }}
 
 build:
-  number: {{ vtk_build }}
+  number: {{ build }}
   skip: true  # [win]
 
 requirements:

--- a/recipes/moose-libmesh-vtk/recipe/meta.yaml
+++ b/recipes/moose-libmesh-vtk/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set vtk_version = vtk_version %}
 {% set friendly_version =  friendly_version %}
-{% set vtk_build = 3 %}
+{% set vtk_build = 0 %}
 {% set sha256 = sha256 %}
 
 package:

--- a/recipes/moose-libmesh/recipe/conda_build_config.yaml
+++ b/recipes/moose-libmesh/recipe/conda_build_config.yaml
@@ -16,15 +16,15 @@ mpi:
 SHORT_VTK_NAME:
   - 6.3
 
-moose_petsc:
- - 3.11.4.01
-
-moose_libmesh_vtk:
- - 6.3.0.01
-
 netcdf:
  - 4.6.2
 
+moose_petsc:
+ - 3.11.4.0
+
+moose_libmesh_vtk:
+ - 6.3.0.0
+
 pin_run_as_build:
-  moose_petsc: x.x.x
+  moose_petsc: x.x.x.x
   moose_libmesh_vtk: x.x.x.x

--- a/recipes/moose-libmesh/recipe/conda_build_config.yaml
+++ b/recipes/moose-libmesh/recipe/conda_build_config.yaml
@@ -17,15 +17,14 @@ SHORT_VTK_NAME:
   - 6.3
 
 moose_petsc:
- - 3.11.4 h42030b3_5           # [osx]
- - 3.11.4 h82e9ade_5           # [linux]
+ - 3.11.4.01
 
 moose_libmesh_vtk:
- - 6.3.0
+ - 6.3.0.01
 
 netcdf:
  - 4.6.2
 
 pin_run_as_build:
   moose_petsc: x.x.x
-  moose_libmesh_vtk: x.x.x
+  moose_libmesh_vtk: x.x.x.x

--- a/recipes/moose-libmesh/recipe/meta.yaml
+++ b/recipes/moose-libmesh/recipe/meta.yaml
@@ -1,8 +1,8 @@
 {% set name = "moose-libmesh" %}
 {% set version = "ef7dd34ad117998e7b7ef909e85a6ae53f57e057" %}
 {% set sha256 = "0003ae875911070d8d33f1aa3db748c6e7003918f4d90c7cd98d5d8bfb2505d3" %}
-{% set friendly_version = "2020.03.16" %}
-{% set libmesh_build = 1 %}
+{% set friendly_version = "2020.03.17.01" %}
+{% set libmesh_build = 0 %}
 
 {% set timpi_version = "e0850710c516f8ee6cfb878d132a149f89dbf9dd" %}
 {% set timpi_sha256 = "eb0d80da298cfcdd28b17c49e0f8e03c0407b6d4e4929ee1a42b3b1d144b461d" %}

--- a/recipes/moose-libmesh/recipe/meta.yaml
+++ b/recipes/moose-libmesh/recipe/meta.yaml
@@ -1,8 +1,8 @@
-{% set name = "moose-libmesh" %}
-{% set version = "ef7dd34ad117998e7b7ef909e85a6ae53f57e057" %}
-{% set sha256 = "0003ae875911070d8d33f1aa3db748c6e7003918f4d90c7cd98d5d8bfb2505d3" %}
-{% set friendly_version = "2020.03.17.01" %}
-{% set libmesh_build = 0 %}
+{% set build = 0 %}
+{% set version = "2020.03.17." + build %}
+
+{% set libmesh_version = "ef7dd34ad117998e7b7ef909e85a6ae53f57e057" %}
+{% set libmesh_sha256 = "0003ae875911070d8d33f1aa3db748c6e7003918f4d90c7cd98d5d8bfb2505d3" %}
 
 {% set timpi_version = "e0850710c516f8ee6cfb878d132a149f89dbf9dd" %}
 {% set timpi_sha256 = "eb0d80da298cfcdd28b17c49e0f8e03c0407b6d4e4929ee1a42b3b1d144b461d" %}
@@ -11,14 +11,14 @@
 {% set metaphysicl_sha256 = "d40a3c9780d1d5ec16f83c213a0bed7965325877dd729e4c3d59bde7424fbe41" %}
 
 package:
-  name: {{ name }}
-  version: {{ friendly_version }}
+  name: moose-libmesh
+  version: {{ version }}
 
 source:
-  - url: https://github.com/libMesh/libmesh/archive/{{ version }}.tar.gz
-    fn: libmesh-{{ version }}.tar.gz
+  - url: https://github.com/libMesh/libmesh/archive/{{ libmesh_version }}.tar.gz
+    fn: libmesh-{{ libmesh_version }}.tar.gz
     folder: src/github.com/libMesh/libmesh
-    sha256: {{ sha256 }}
+    sha256: {{ libmesh_sha256 }}
 
   - url: https://github.com/libMesh/TIMPI/archive/{{ timpi_version }}.tar.gz
     fn: timp-{{ timpi_version }}.tar.gz
@@ -31,7 +31,7 @@ source:
     sha256: {{ metaphysicl_sha256 }}
 
 build:
-  number: {{ libmesh_build }}
+  number: {{ build }}
   skip: true                                            # [win]
 
 requirements:

--- a/recipes/moose-libmesh/recipe/meta.yaml
+++ b/recipes/moose-libmesh/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set build = 0 %}
-{% set version = "2020.03.17." + build %}
+{% set version = "2020.03.17." + build|string %}
 
 {% set libmesh_version = "ef7dd34ad117998e7b7ef909e85a6ae53f57e057" %}
 {% set libmesh_sha256 = "0003ae875911070d8d33f1aa3db748c6e7003918f4d90c7cd98d5d8bfb2505d3" %}

--- a/recipes/moose-mpich/recipe/conda_build_config.yaml
+++ b/recipes/moose-mpich/recipe/conda_build_config.yaml
@@ -11,10 +11,10 @@ MACOSX_DEPLOYMENT_TARGET:      # [osx]
   - 10.9                       # [osx]
 
 moose_compilers:
-  - 2020.03.02
+  - 2020.03.17.01
 
 pin_run_as_build:
-  moose_compilers: x.x.x
+  moose_compilers: x.x.x.x
 
 libllvm:
   - 9.0.1 ha1b3eb9_0

--- a/recipes/moose-mpich/recipe/conda_build_config.yaml
+++ b/recipes/moose-mpich/recipe/conda_build_config.yaml
@@ -11,7 +11,7 @@ MACOSX_DEPLOYMENT_TARGET:      # [osx]
   - 10.9                       # [osx]
 
 moose_compilers:
-  - 2020.03.17.01
+  - 2020.03.17.0
 
 pin_run_as_build:
   moose_compilers: x.x.x.x

--- a/recipes/moose-mpich/recipe/meta.yaml
+++ b/recipes/moose-mpich/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "3.3.2" %}
-{% set mpich_build = 4 %}
+{% set version = "3.3.2.01" %}
+{% set mpich_build = 0 %}
 
 package:
   name: moose-mpich

--- a/recipes/moose-mpich/recipe/meta.yaml
+++ b/recipes/moose-mpich/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set build = 0 %}
 {% set download_version = "3.3.2" %}
 
-{% set version = download_version + "." + build %}
+{% set version = download_version + "." + build|string %}
 
 package:
   name: moose-mpich

--- a/recipes/moose-mpich/recipe/meta.yaml
+++ b/recipes/moose-mpich/recipe/meta.yaml
@@ -1,17 +1,19 @@
-{% set version = "3.3.2.01" %}
-{% set mpich_build = 0 %}
+{% set build = 0 %}
+{% set download_version = "3.3.2" %}
+
+{% set version = download_version + "." + build %}
 
 package:
   name: moose-mpich
   version: {{ version }}
 
 source:
-  fn: mpich-{{ version }}.tar.gz
-  url: http://www.mpich.org/static/downloads/{{ version }}/mpich-{{ version }}.tar.gz
+  fn: mpich-{{ download_version }}.tar.gz
+  url: http://www.mpich.org/static/downloads/{{ download_version }}/mpich-{{ download_version }}.tar.gz
   sha256: 4bfaf8837a54771d3e4922c84071ef80ffebddbb6971a006038d91ee7ef959b9
 
 build:
-  number: {{ mpich_build }}
+  number: {{ build }}
   skip: True  # [win]
   run_exports:
     - {{ pin_subpackage('moose-mpich', max_pin='x.x') }}

--- a/recipes/moose-petsc/recipe/conda_build_config.yaml
+++ b/recipes/moose-petsc/recipe/conda_build_config.yaml
@@ -14,7 +14,7 @@ mpi:
   - moose-mpich
 
 moose_mpich:
-  - 3.3.2
+  - 3.3.2.01
 
 libblas:
   - 3.8.0 15_openblas # [osx]
@@ -29,7 +29,7 @@ libopenblas:
   - 0.3.8 h3d69b6c_0  # [osx]
 
 pin_run_as_build:
-  moose_mpich: x.x.x
+  moose_mpich: x.x.x.x
   libblas: x.x.x
   libcblas: x.x.x
   liblapack: x.x.x

--- a/recipes/moose-petsc/recipe/conda_build_config.yaml
+++ b/recipes/moose-petsc/recipe/conda_build_config.yaml
@@ -14,7 +14,7 @@ mpi:
   - moose-mpich
 
 moose_mpich:
-  - 3.3.2.01
+  - 3.3.2.0
 
 libblas:
   - 3.8.0 15_openblas # [osx]

--- a/recipes/moose-petsc/recipe/meta.yaml
+++ b/recipes/moose-petsc/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set build = 0 %}
 {% set download_version = "3.11.4" %}
 
-{% set version = download_version + "." + build %}
+{% set version = download_version + "." + build|string %}
 {% set sha256 = "319cb5a875a692a67fe5b1b90009ba8f182e21921ae645d38106544aff20c3c1" %}
 {% set petsc_build = 0 %}
 

--- a/recipes/moose-petsc/recipe/meta.yaml
+++ b/recipes/moose-petsc/recipe/meta.yaml
@@ -1,4 +1,7 @@
-{% set version = "3.11.4.01" %}
+{% set build = 0 %}
+{% set download_version = "3.11.4" %}
+
+{% set version = download_version + "." + build %}
 {% set sha256 = "319cb5a875a692a67fe5b1b90009ba8f182e21921ae645d38106544aff20c3c1" %}
 {% set petsc_build = 0 %}
 
@@ -7,8 +10,8 @@ package:
   version: {{ version }}
 
 source:
-  fn: petsc-{{ version }}.tar.gz
-  url: http://ftp.mcs.anl.gov/pub/petsc/release-snapshots/petsc-{{ version }}.tar.gz
+  fn: petsc-{{ download_version }}.tar.gz
+  url: http://ftp.mcs.anl.gov/pub/petsc/release-snapshots/petsc-{{ download_version }}.tar.gz
   sha256: {{ sha256 }}
   patches:
     - ignore-not-invalid.patch
@@ -16,7 +19,7 @@ source:
 
 build:
   skip: true  # [win]
-  number: {{ petsc_build }}
+  number: {{ build }}
   run_exports:
     - {{ pin_subpackage('moose-petsc', max_pin='x.x')}}
 
@@ -27,7 +30,7 @@ requirements:
 
   host:
     - cmake
-    - moose-mpich
+    - moose-mpich {{ moose_mpich }}
     - libblas     {{ libblas }}     # [osx]
     - libcblas    {{ libcblas }}    # [osx]
     - liblapack   {{ liblapack }}   # [osx]
@@ -35,7 +38,7 @@ requirements:
 
   run:
     - cmake
-    - moose-mpich
+    - moose-mpich {{ moose_mpich }}
     - libblas     {{ libblas }}     # [osx]
     - libcblas    {{ libcblas }}    # [osx]
     - liblapack   {{ liblapack }}   # [osx]

--- a/recipes/moose-petsc/recipe/meta.yaml
+++ b/recipes/moose-petsc/recipe/meta.yaml
@@ -1,6 +1,6 @@
-{% set version = "3.11.4" %}
+{% set version = "3.11.4.01" %}
 {% set sha256 = "319cb5a875a692a67fe5b1b90009ba8f182e21921ae645d38106544aff20c3c1" %}
-{% set petsc_build = 5 %}
+{% set petsc_build = 0 %}
 
 package:
   name: moose-petsc

--- a/recipes/moose/recipe/conda_build_config.yaml
+++ b/recipes/moose/recipe/conda_build_config.yaml
@@ -1,6 +1,5 @@
 moose_libmesh:
- - 2020.03.16 h1d7de4d_1  # [osx]
- - 2020.03.16 h3dd2d4e_1  # [linux]
+ - 2020.03.17.01
 
 pin_run_as_build:
   moose_libmesh: x.x.x

--- a/recipes/moose/recipe/conda_build_config.yaml
+++ b/recipes/moose/recipe/conda_build_config.yaml
@@ -1,5 +1,5 @@
 moose_libmesh:
- - 2020.03.17.01
+ - 2020.03.17.0
 
 pin_run_as_build:
-  moose_libmesh: x.x.x
+  moose_libmesh: x.x.x.x

--- a/recipes/moose/recipe/meta.yaml
+++ b/recipes/moose/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set build = 0 %}
-{% set version = "2020.03.17." + build %}
+{% set version = "2020.03.17." + build|string %}
 
 {% set sha256 = "1f9e83570f0670511998f609a2b4b3ddd5dc02563b052b6cd3af24a59452cece" %}
 

--- a/recipes/moose/recipe/meta.yaml
+++ b/recipes/moose/recipe/meta.yaml
@@ -20,7 +20,7 @@ requirements:
     - moose-libmesh {{ moose_libmesh }}
 
   run:
-    - moose-libmesh
+    - moose-libmesh {{ moose_libmesh }}
 
 test:
   commands:

--- a/recipes/moose/recipe/meta.yaml
+++ b/recipes/moose/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "moose" %}
-{% set version = "2020.03.16" %}
+{% set version = "2020.03.17" %}
 {% set sha256 = "1f9e83570f0670511998f609a2b4b3ddd5dc02563b052b6cd3af24a59452cece" %}
 
 package:
@@ -11,7 +11,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1  # [linux,osx]
+  number: 0  # [linux,osx]
   skip: true # [win]
 
 requirements:

--- a/recipes/moose/recipe/meta.yaml
+++ b/recipes/moose/recipe/meta.yaml
@@ -1,9 +1,10 @@
-{% set name = "moose" %}
-{% set version = "2020.03.17" %}
+{% set build = 0 %}
+{% set version = "2020.03.17." + build %}
+
 {% set sha256 = "1f9e83570f0670511998f609a2b4b3ddd5dc02563b052b6cd3af24a59452cece" %}
 
 package:
-  name: {{ name }}
+  name: moose
   version: {{ version }}
 
 source:


### PR DESCRIPTION
Rebuild everything (except moose-tools). Tie in a new set of dependencies
using date, followed by an ad hoc  version. No longer can we depend on
build number.

Closes #58