### PR TITLE
Remove string hash for moose-tools

### DIFF
--- a/recipes/moose-tools/recipe/meta.yaml
+++ b/recipes/moose-tools/recipe/meta.yaml
@@ -1,6 +1,5 @@
 {% set build = 0 %}
-{% set strbuild = "build_" + build|string %}
-{% set version = "2020.03.23" %}
+{% set version = "2020.03.24" %}
 
 {% set sha256 = "3a12dc808c116f6593f7c95519ed2410b3e61bde9c3b426a58c07c7f6a6dd4c2" %}
 
@@ -14,7 +13,6 @@ source:
 
 build:
   number: {{ build }}
-  string: {{ strbuild }}
   skip: true                 # [win]
 
 requirements:


### PR DESCRIPTION
Just update moose-tools to include numpy, and leave the altering of the
build hash alone. Python 36/37 was doing it right before.

Closes #64