### PR TITLE
Create a working VTK dependency

### DIFF
--- a/build_packages.sh
+++ b/build_packages.sh
@@ -77,8 +77,7 @@ else
 fi
 
 # Clear any previous build environment
-print_and_run conda clean --all --yes
-exitIfReturnCode $?
+conda clean --all --yes 2>&1 > /dev/null
 print_and_run conda build purge-all
 exitIfReturnCode $?
 

--- a/recipes/moose-tools/recipe/conda_build_config.yaml
+++ b/recipes/moose-tools/recipe/conda_build_config.yaml
@@ -2,5 +2,15 @@ python:
  - 3.7
  - 3.6
 
+vtk:
+ - 8.2.0 py37hcba847f_203 # [osx]
+ - 8.2.0 py36hcba847f_203 # [osx]
+ - 8.2.0 py37hfdee58b_203 # [linux]
+ - 8.2.0 py36hfdee58b_203 # [linux]
+
+zip_keys:
+ - python
+ - vtk
+
 pin_run_as_build:
  python: x.x

--- a/recipes/moose-tools/recipe/meta.yaml
+++ b/recipes/moose-tools/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set build = 0 %}
-{% set version = "2020.03.24" %}
+{% set version = "2020.03.31" %}
 
 {% set sha256 = "3a12dc808c116f6593f7c95519ed2410b3e61bde9c3b426a58c07c7f6a6dd4c2" %}
 
@@ -18,6 +18,7 @@ build:
 requirements:
   build:
     - python {{ python }}
+    - vtk {{ vtk }}
   run:
     - numpy
     - pyqt
@@ -31,11 +32,11 @@ requirements:
     - mock
     - lxml
     - scikit-image
-    - vtk
+    - vtk {{ vtk }}
     - pylatexenc
     - jinja2
     - mako
-    - python
+    - python {{ python }}
 
 test:
   commands:


### PR DESCRIPTION
Have moose-tools depend on VTK=8.2.0_203
Perform a conda clean in addition to purge-all, before a build takes place.

Closes #66