### PR TITLE
Bump up the PETSc version

### DIFF
--- a/recipes/moose-petsc/recipe/meta.yaml
+++ b/recipes/moose-petsc/recipe/meta.yaml
@@ -1,8 +1,8 @@
 {% set build = 0 %}
 {% set strbuild = "build_" + build|string %}
-{% set version = "3.11.4" %}
+{% set version = "3.12.5" %}
 
-{% set sha256 = "319cb5a875a692a67fe5b1b90009ba8f182e21921ae645d38106544aff20c3c1" %}
+{% set sha256 = "d676eb67e79314d6cca6422d7c477d2b192c830b89d5edc6b46934f7453bcfc0" %}
 
 package:
   name: moose-petsc


### PR DESCRIPTION
Begin supplying PETSc 3.12.5 via Conda.

Closes #69

Tagging @fdkong 